### PR TITLE
Choice of the cache directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ SRC += sdk/megabdb.cpp sdk/megaclient.cpp sdk/megacrypto.cpp
 OUT = $(TARGET)
 OBJ = $(patsubst %.cpp,%.o,$(patsubst %.c,%.o,$(SRC)))
 
-.PHONY:	
+.PHONY:	clean install
 
 
 # include directories
@@ -45,3 +45,9 @@ $(OUT): $(OBJ)
 
 clean:	
 	rm -f $(OBJ) $(OUT)
+
+install: $(OUT)
+	mkdir -p /usr/share/doc/MegaFuse
+	cp FAQ.txt LICENSE.txt README.md megafuse.conf /usr/share/doc/MegaFuse/
+	cp megafuse.service megafuse@.service /lib/systemd/system/
+	cp $(OUT) /usr/bin/

--- a/inc/Config.h
+++ b/inc/Config.h
@@ -14,6 +14,7 @@
         std::string PASSWORD;
         std::string APPKEY;
         std::string MOUNTPOINT;
+        std::string CACHEPATH;
 		int fuseindex;
         private:
         Config();

--- a/megafuse.conf
+++ b/megafuse.conf
@@ -13,3 +13,7 @@
 #### you can specify a mountpoint here, only absolute paths are supported.
 
 #MOUNTPOINT = /tmp/s
+
+#### path for the cached files; /tmp is the default, change it if your /tmp is small
+
+CACHEPATH = /tmp

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -40,7 +40,7 @@ bool Config::parseCommandLine(int argc, char**argv)
             configFile=optarg;
             cout <<"ss "<<configFile<<endl;
             break;
-		case 'f':
+        case 'f':
             fuseindex = optind;
             return false;
             break;
@@ -149,6 +149,7 @@ void Config::LoadConfig()
             CHECK_VARIABLE(PASSWORD);
             CHECK_VARIABLE(APPKEY);
             CHECK_VARIABLE(MOUNTPOINT);
+            CHECK_VARIABLE(CACHEPATH);
             else
                 cerr<<"Could not understand the keyword at line"<<linenum<<": "<<strbuf<<endl;
         }
@@ -162,7 +163,9 @@ void Config::LoadConfig()
 	if(PASSWORD == "")
 	    PASSWORD = getString("Enter your password: ",true);
 	while(2 != countEntriesInDir(MOUNTPOINT))
-		MOUNTPOINT = getString("Specify a vailid mountpoint (an empty directory): ",false);
+		MOUNTPOINT = getString("Specify a valid mountpoint (an empty directory): ",false);
+	while(0 > countEntriesInDir(CACHEPATH))
+		CACHEPATH = getString("Specify a valid cache path (eg: /tmp): ",false);
 }
 
 Config::Config():APPKEY("MEGASDK"),fuseindex(-1),configFile("megafuse.conf")

--- a/src/file_cache_row.cpp
+++ b/src/file_cache_row.cpp
@@ -3,6 +3,7 @@
  */
 
 #include "file_cache_row.h"
+#include "Config.h"
 #include <fcntl.h>
 #include <stdlib.h>
 #include <unistd.h>
@@ -12,8 +13,8 @@
 
 file_cache_row::file_cache_row(): td(-1),status(INVALID),size(0),available_bytes(0),n_clients(0),startOffset(0),modified(false),handle(0)
 {
-	char filename[] = "/tmp/mega.XXXXXX";
-	close (mkstemp(filename));
+	std::string filename = Config::getInstance()->CACHEPATH + "/mega.XXXXXX";
+	close (mkstemp(&filename[0]));
 	localname = filename;
 	printf("creato il file %s\n",localname.c_str());
 }


### PR DESCRIPTION
My server has a very small /tmp, which caused MegaFuse to fail after a time. Unfortunately, I saw that "/tmp" was hardcoded.
I have next to no knowledge in C++, but with the help of others, I managed to adapt the software to my needs. So far it seems to work fine.
If you don't spot problems in the changes, I would be glad if you would include these.