### PR TITLE
Added math.h header to file_cache_row.cpp

### DIFF
--- a/src/file_cache_row.cpp
+++ b/src/file_cache_row.cpp
@@ -7,6 +7,7 @@
 #include <fcntl.h>
 #include <stdlib.h>
 #include <unistd.h>
+#include <math.h>
 
 #include <megaclient.h>
 #include <sys/stat.h>


### PR DESCRIPTION
Added #include<math.h> 
Fixed error while running make.

Error:

src/file_cache_row.cpp: In static member function ‘static int CacheManager::numChunks(size_t)’:
src/file_cache_row.cpp:70:59: error: ‘ceil’ was not declared in this scope
  return 8 + ceil(float(pos-end)/(8.0*ChunkedHash::SEGSIZE));