### PR TITLE
Included cmath to resolve failed build on Ubuntu 17.04

### DIFF
--- a/src/file_cache_row.cpp
+++ b/src/file_cache_row.cpp
@@ -5,6 +5,7 @@
 #include "file_cache_row.h"
 #include "Config.h"
 #include <fcntl.h>
+#include <cmath>
 #include <stdlib.h>
 #include <unistd.h>
 


### PR DESCRIPTION
Making a build, an compiler error was triggered:

> src/file_cache_row.cpp:72:59: error: ‘ceil’ was not declared in this scope

Including `cmath` or `math.h` solves the issue.