### PR TITLE
Failed to compile if #include <math.h> not present

### DIFF
--- a/src/file_cache_row.cpp
+++ b/src/file_cache_row.cpp
@@ -7,6 +7,7 @@
 #include <fcntl.h>
 #include <stdlib.h>
 #include <unistd.h>
+#include <math.h>
 
 #include <megaclient.h>
 #include <sys/stat.h>


### PR DESCRIPTION
System: GNU/Linux Debian 9