### PR TITLE
include cmath to resolve missing ceil()

### DIFF
--- a/src/file_cache_row.cpp
+++ b/src/file_cache_row.cpp
@@ -7,6 +7,7 @@
 #include <fcntl.h>
 #include <stdlib.h>
 #include <unistd.h>
+#include <cmath>
 
 #include <megaclient.h>
 #include <sys/stat.h>


### PR DESCRIPTION
Failed to build on debian 9.0